### PR TITLE
Move global background image from HomeScreen to App root

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -90,6 +90,14 @@ export default function App() {
 
   return (
     <LanguageContext.Provider value={lang}>
+      {/* Global background image */}
+      <div
+        className="fixed inset-0 bg-cover bg-center bg-no-repeat"
+        style={{
+          backgroundImage: 'url(/art/home-bg.jpg)',
+          backgroundColor: '#0f0a1a',
+        }}
+      />
       <div className={isHome ? 'relative' : 'max-w-md mx-auto relative'}>
         {/* Connection status banner */}
         {!game.connected && game.screen === 'game' && (

--- a/client/src/screens/HomeScreen.tsx
+++ b/client/src/screens/HomeScreen.tsx
@@ -11,14 +11,6 @@ export default function HomeScreen({ setScreen }: HomeScreenProps) {
 
   return (
     <div className="min-h-dvh flex flex-col relative overflow-hidden animate-fade-in">
-      {/* Background image with fallback gradient */}
-      <div
-        className="absolute inset-0 bg-cover bg-center bg-no-repeat"
-        style={{
-          backgroundImage: 'url(/art/home-bg.jpg)',
-          backgroundColor: '#0f0a1a',
-        }}
-      />
       {/* Subtle bottom fade only — for button readability */}
       <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
 


### PR DESCRIPTION
## Summary
Refactored the background image implementation to be a global element at the App root level instead of being scoped to the HomeScreen component. This ensures consistent background styling across all screens and improves the visual hierarchy.

## Changes
- Moved the background image div from `HomeScreen.tsx` to `App.tsx` root provider
- Changed background positioning from `absolute` to `fixed` to maintain consistent appearance during navigation
- Removed duplicate background styling from HomeScreen component
- Preserved the gradient overlay in HomeScreen for button readability

## Implementation Details
- The background is now rendered at the App level with `fixed inset-0` positioning, ensuring it stays in place and covers the entire viewport
- The fallback background color (`#0f0a1a`) is maintained for loading states
- HomeScreen's gradient overlay (`from-black/70 via-transparent to-transparent`) remains for proper contrast on interactive elements
- This approach provides better performance by rendering the background once at the root level rather than conditionally in child components

https://claude.ai/code/session_01PcSFfg11sEdx8HL46cNcRe