### PR TITLE
Fix leave button unresponsive when server is unreachable

### DIFF
--- a/client/src/hooks/useGameState.ts
+++ b/client/src/hooks/useGameState.ts
@@ -124,6 +124,11 @@ export function useGameState(initialScreen?: AppScreen) {
 
   const leaveGame = useCallback(() => {
     emit('game:leave');
+    // Optimistically reset client state — don't wait for server response
+    // (if the server is unreachable, game:left would never arrive)
+    setGameState(null);
+    setScreen('home');
+    setError(null);
   }, [emit]);
 
   const endGame = useCallback(() => {


### PR DESCRIPTION
## Summary
- Optimistically reset client state when leaving a game instead of waiting for the server `game:left` response
- Fixes the "Salir" button doing nothing when the server has restarted or the socket is disconnected

## Test plan
- [ ] Create a game, click leave — should return to home immediately
- [ ] Simulate server unreachable (stop server), click leave — should still return to home

🤖 Generated with [Claude Code](https://claude.com/claude-code)