### PR TITLE
Fix language toggle flag button not responding to clicks

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -118,7 +118,7 @@ export default function App() {
         {/* Connection status banner */}
         {!game.connected && game.screen === 'game' && (
           <div className="fixed top-0 left-0 right-0 z-50 bg-rose-600 text-white text-center text-sm py-2 px-4 animate-fade-in">
-            Reconectando...
+            {lang.t('connection.reconnecting')}
           </div>
         )}
         {/* Leave button on all game screens */}

--- a/client/src/screens/HomeScreen.tsx
+++ b/client/src/screens/HomeScreen.tsx
@@ -12,12 +12,12 @@ export default function HomeScreen({ setScreen }: HomeScreenProps) {
   return (
     <div className="min-h-dvh flex flex-col relative overflow-hidden animate-fade-in">
       {/* Subtle bottom fade only — for button readability */}
-      <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
+      <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent pointer-events-none" />
 
       {/* Language toggle */}
       <button
         onClick={() => setLanguage(language === 'es' ? 'en' : 'es')}
-        className="absolute top-4 right-4 z-10 text-2xl cursor-pointer hover:scale-110 transition-transform active:scale-95 drop-shadow-lg"
+        className="absolute top-4 right-4 z-20 text-2xl cursor-pointer hover:scale-110 transition-transform active:scale-95 drop-shadow-lg"
         aria-label="Toggle language"
       >
         {language === 'es' ? '🇬🇧' : '🇪🇸'}

--- a/client/src/translations.ts
+++ b/client/src/translations.ts
@@ -79,6 +79,9 @@ const translations = {
     'results.pickHostHint': '¿Quién elige la siguiente palabra?',
     'results.confirm': 'Confirmar',
 
+    // Connection
+    'connection.reconnecting': 'Reconectando...',
+
     // Errors
     'error.room_not_found': 'Sala no encontrada',
     'error.game_in_progress': 'La partida ya comenzó',
@@ -179,6 +182,9 @@ const translations = {
     'results.pickHost': 'Pick next host',
     'results.pickHostHint': 'Who picks the next word?',
     'results.confirm': 'Confirm',
+
+    // Connection
+    'connection.reconnecting': 'Reconnecting...',
 
     // Errors
     'error.room_not_found': 'Room not found',


### PR DESCRIPTION
The UK/Spain flag button on the home screen was unclickable because the buttons container div (relative z-10 flex-1) filled the entire viewport height and shared the same z-index as the flag button. Being later in DOM order, it captured all click events. Fixed by raising the flag button to z-20 and adding pointer-events-none to the gradient overlay.

Also translated the hardcoded "Reconectando..." banner to use the i18n system so it displays in the selected language.

https://claude.ai/code/session_01KtwVQhNeFPSguzoNFtVE9S