### PR TITLE
Add spectator mode to allow players to watch games

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,7 @@ import VotingScreen from './screens/VotingScreen';
 import PlayingScreen from './screens/PlayingScreen';
 import ResultsScreen from './screens/ResultsScreen';
 import LeaveButton from './components/LeaveButton';
+import SpectatorBanner from './components/SpectatorBanner';
 
 function getInitialJoinCode(): string {
   const params = new URLSearchParams(window.location.search);
@@ -31,6 +32,8 @@ export default function App() {
   const game = useGameState(initialJoinCode ? 'join' : undefined);
   const [joinCode] = useState(initialJoinCode);
 
+  const isSpectator = game.gameState?.isSpectator ?? false;
+
   const renderScreen = () => {
     // If in a game, show the phase-appropriate screen
     if (game.screen === 'game' && game.gameState) {
@@ -42,6 +45,7 @@ export default function App() {
               gameState={gs}
               startGame={game.startGame}
               setMode={game.setMode}
+              convertToPlayer={game.convertToPlayer}
             />
           );
         case 'setup':
@@ -93,6 +97,7 @@ export default function App() {
           <JoinScreen
             setScreen={game.setScreen}
             joinGame={game.joinGame}
+            watchGame={game.watchGame}
             error={game.error}
             initialCode={joinCode}
           />
@@ -120,6 +125,13 @@ export default function App() {
           <div className="fixed top-0 left-0 right-0 z-50 bg-rose-600 text-white text-center text-sm py-2 px-4 animate-fade-in">
             {lang.t('connection.reconnecting')}
           </div>
+        )}
+        {/* Spectator banner */}
+        {game.screen === 'game' && isSpectator && (
+          <SpectatorBanner
+            canConvert={game.gameState?.phase === 'lobby'}
+            onConvert={game.convertToPlayer}
+          />
         )}
         {/* Leave button on all game screens */}
         {game.screen === 'game' && game.gameState && (

--- a/client/src/components/PlayerCard.tsx
+++ b/client/src/components/PlayerCard.tsx
@@ -43,6 +43,11 @@ export default function PlayerCard({
               Host
             </span>
           )}
+          {player.isSpectator && (
+            <span className="text-xs bg-amber-600/30 text-amber-400 px-2 py-0.5 rounded-full">
+              Spectator
+            </span>
+          )}
           {!player.isConnected && (
             <span className="text-xs bg-rose-600/30 text-rose-400 px-2 py-0.5 rounded-full">
               ⚡ offline

--- a/client/src/components/SpectatorBanner.tsx
+++ b/client/src/components/SpectatorBanner.tsx
@@ -1,0 +1,24 @@
+import { useLanguage } from '../hooks/useLanguage';
+
+interface SpectatorBannerProps {
+  canConvert: boolean;
+  onConvert: () => void;
+}
+
+export default function SpectatorBanner({ canConvert, onConvert }: SpectatorBannerProps) {
+  const { t } = useLanguage();
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-40 bg-amber-600/90 backdrop-blur-sm text-white text-center text-sm py-2 px-4 flex items-center justify-center gap-3">
+      <span>{t('spectator.banner')}</span>
+      {canConvert && (
+        <button
+          onClick={onConvert}
+          className="text-xs bg-white/20 hover:bg-white/30 rounded-full px-3 py-1 transition-colors cursor-pointer"
+        >
+          {t('spectator.joinAsPlayer')}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/client/src/hooks/useGameState.ts
+++ b/client/src/hooks/useGameState.ts
@@ -78,6 +78,14 @@ export function useGameState(initialScreen?: AppScreen) {
     emit('game:join', { code, playerName });
   }, [emit]);
 
+  const watchGame = useCallback((code: string, playerName: string) => {
+    emit('game:watch', { code, playerName });
+  }, [emit]);
+
+  const convertToPlayer = useCallback(() => {
+    emit('game:convertToPlayer');
+  }, [emit]);
+
   const setMode = useCallback((mode: GameMode) => {
     emit('game:setMode', { mode });
   }, [emit]);
@@ -150,6 +158,8 @@ export function useGameState(initialScreen?: AppScreen) {
     connected,
     createGame,
     joinGame,
+    watchGame,
+    convertToPlayer,
     setMode,
     startGame,
     setWord,

--- a/client/src/screens/CluesScreen.tsx
+++ b/client/src/screens/CluesScreen.tsx
@@ -24,9 +24,9 @@ export default function CluesScreen({
 
   const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
 
-  const activePlayers = gameState.players.filter((p) => !p.isEliminated);
+  const activePlayers = gameState.players.filter((p) => !p.isEliminated && !p.isSpectator);
   const currentPlayer = activePlayers[gameState.turnIndex];
-  const isMyTurn = currentPlayer?.id === gameState.playerId;
+  const isMyTurn = !gameState.isSpectator && currentPlayer?.id === gameState.playerId;
   const allDone = gameState.turnIndex >= activePlayers.length;
 
   // Countdown timer based on server turnDeadline
@@ -177,7 +177,7 @@ export default function CluesScreen({
       )}
 
       {/* Host controls when round is done */}
-      {allDone && gameState.isHost && (
+      {allDone && gameState.isHost && !gameState.isSpectator && (
         <div className="space-y-3 pb-safe">
           <Button onClick={startVoting}>{t('clues.goToVoting')}</Button>
           <Button onClick={nextRound} variant="secondary">

--- a/client/src/screens/JoinScreen.tsx
+++ b/client/src/screens/JoinScreen.tsx
@@ -7,19 +7,28 @@ import type { AppScreen } from '../types';
 interface JoinScreenProps {
   setScreen: (screen: AppScreen) => void;
   joinGame: (code: string, name: string) => void;
+  watchGame: (code: string, name: string) => void;
   error: string | null;
   initialCode?: string;
 }
 
-export default function JoinScreen({ setScreen, joinGame, error, initialCode = '' }: JoinScreenProps) {
+export default function JoinScreen({ setScreen, joinGame, watchGame, error, initialCode = '' }: JoinScreenProps) {
   const { t } = useLanguage();
   const [code, setCode] = useState(initialCode);
   const [name, setName] = useState('');
 
+  const canSubmit = code.trim().length === 4 && !!name.trim();
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (code.trim().length === 4 && name.trim()) {
+    if (canSubmit) {
       joinGame(code.trim().toUpperCase(), name.trim());
+    }
+  };
+
+  const handleWatch = () => {
+    if (canSubmit) {
+      watchGame(code.trim().toUpperCase(), name.trim());
     }
   };
 
@@ -57,8 +66,11 @@ export default function JoinScreen({ setScreen, joinGame, error, initialCode = '
         {error && (
           <p className="text-rose-400 text-sm text-center">{t(`error.${error}` as any)}</p>
         )}
-        <Button type="submit" disabled={code.trim().length !== 4 || !name.trim()}>
+        <Button type="submit" disabled={!canSubmit}>
           {t('join.button')}
+        </Button>
+        <Button type="button" variant="secondary" disabled={!canSubmit} onClick={handleWatch}>
+          {t('join.watch')}
         </Button>
       </form>
     </div>

--- a/client/src/screens/LobbyScreen.tsx
+++ b/client/src/screens/LobbyScreen.tsx
@@ -9,20 +9,27 @@ interface LobbyScreenProps {
   gameState: GameState;
   startGame: () => void;
   setMode: (mode: GameMode) => void;
+  convertToPlayer: () => void;
 }
 
-export default function LobbyScreen({ gameState, startGame, setMode }: LobbyScreenProps) {
+export default function LobbyScreen({ gameState, startGame, setMode, convertToPlayer }: LobbyScreenProps) {
   const { t } = useLanguage();
-  const canStart = gameState.players.length >= 3;
+  const actualPlayers = gameState.players.filter((p) => !p.isSpectator);
+  const canStart = actualPlayers.length >= 3;
 
   return (
-    <div className="min-h-dvh flex flex-col p-6 animate-fade-in">
+    <div className={`min-h-dvh flex flex-col p-6 animate-fade-in ${gameState.isSpectator ? 'pt-12' : ''}`}>
       <div className="pt-4 mb-6">
         <RoomCode code={gameState.code} />
       </div>
 
       <div className="text-center text-slate-400 text-sm mb-4">
-        {gameState.players.length} {t('lobby.players')}
+        {actualPlayers.length} {t('lobby.players')}
+        {gameState.spectatorCount > 0 && (
+          <span className="ml-2 text-amber-400">
+            · {t('lobby.spectators', { count: gameState.spectatorCount })}
+          </span>
+        )}
       </div>
 
       <div className="flex-1 space-y-3 overflow-y-auto mb-6">
@@ -68,7 +75,19 @@ export default function LobbyScreen({ gameState, startGame, setMode }: LobbyScre
           )}
         </div>
 
-        {gameState.isHost ? (
+        {gameState.isSpectator ? (
+          <div className="space-y-2">
+            <Button onClick={convertToPlayer}>
+              {t('spectator.joinAsPlayer')}
+            </Button>
+            <div className="text-center text-slate-400">
+              <p>{t('lobby.waiting', { host: gameState.hostName })}</p>
+              <div className="mt-2">
+                <WaitingDots />
+              </div>
+            </div>
+          </div>
+        ) : gameState.isHost ? (
           <div className="space-y-2">
             <Button onClick={startGame} disabled={!canStart}>
               {t('lobby.start')}

--- a/client/src/screens/PlayingScreen.tsx
+++ b/client/src/screens/PlayingScreen.tsx
@@ -19,7 +19,7 @@ export default function PlayingScreen({ gameState, revealImpostor }: PlayingScre
 
       {/* Player avatars in a circle-like arrangement */}
       <div className="flex flex-wrap justify-center gap-3 mb-10 max-w-xs">
-        {gameState.players.map((player) => (
+        {gameState.players.filter((p) => !p.isSpectator).map((player) => (
           <div key={player.id} className="flex flex-col items-center gap-1">
             <div
               className="w-12 h-12 rounded-full flex items-center justify-center text-xl animate-pulse"

--- a/client/src/screens/ResultsScreen.tsx
+++ b/client/src/screens/ResultsScreen.tsx
@@ -24,7 +24,7 @@ export default function ResultsScreen({ gameState, playAgain, endGame, transferH
   }, []);
 
   const impostor = gameState.players.find((p) => p.id === gameState.impostorId);
-  const activePlayers = gameState.players.filter((p) => !p.isEliminated);
+  const activePlayers = gameState.players.filter((p) => !p.isEliminated && !p.isSpectator);
 
   // Count votes per player (only relevant for online mode)
   const voteCounts: Record<string, number> = {};
@@ -63,7 +63,7 @@ export default function ResultsScreen({ gameState, playAgain, endGame, transferH
 
         <div className="flex-1 space-y-3 overflow-y-auto mb-6">
           {gameState.players
-            .filter((p) => p.id !== gameState.playerId && p.isConnected)
+            .filter((p) => p.id !== gameState.playerId && p.isConnected && !p.isSpectator)
             .map((player) => (
               <div
                 key={player.id}

--- a/client/src/screens/RevealScreen.tsx
+++ b/client/src/screens/RevealScreen.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Button from '../components/Button';
+import WaitingDots from '../components/WaitingDots';
 import { useLanguage } from '../hooks/useLanguage';
 import type { GameState } from '../types';
 
@@ -13,9 +14,36 @@ export default function RevealScreen({ gameState, markRoleReady }: RevealScreenP
   const [revealed, setRevealed] = useState(false);
 
   const me = gameState.players.find((p) => p.id === gameState.playerId);
-  const readyCount = gameState.players.filter((p) => p.hasSeenRole).length;
-  const totalCount = gameState.players.length;
+  const actualPlayers = gameState.players.filter((p) => !p.isSpectator);
+  const readyCount = actualPlayers.filter((p) => p.hasSeenRole).length;
+  const totalCount = actualPlayers.length;
   const allReady = readyCount === totalCount;
+
+  // Spectators see a waiting view with progress
+  if (gameState.isSpectator) {
+    return (
+      <div className="min-h-dvh flex flex-col items-center justify-center p-6 pt-12 animate-fade-in">
+        <div className="text-6xl mb-6">🃏</div>
+        <p className="text-slate-400 text-lg text-center mb-6">
+          {t('spectator.watching')}
+        </p>
+        <div className="w-full max-w-sm space-y-3">
+          <p className="text-center text-slate-400 text-sm">
+            {t('reveal.playersReady', { count: readyCount, total: totalCount })}
+          </p>
+          <div className="w-full h-2 bg-slate-800/60 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-violet-500 rounded-full transition-all duration-500"
+              style={{ width: `${totalCount > 0 ? (readyCount / totalCount) * 100 : 0}%` }}
+            />
+          </div>
+          <div className="flex justify-center mt-2">
+            <WaitingDots />
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   const handleTap = () => {
     setRevealed(!revealed);

--- a/client/src/screens/VotingScreen.tsx
+++ b/client/src/screens/VotingScreen.tsx
@@ -13,7 +13,7 @@ export default function VotingScreen({ gameState, vote }: VotingScreenProps) {
   const { t } = useLanguage();
   const [selected, setSelected] = useState<string | null>(null);
 
-  const activePlayers = gameState.players.filter((p) => !p.isEliminated);
+  const activePlayers = gameState.players.filter((p) => !p.isEliminated && !p.isSpectator);
   const myVote = gameState.votes[gameState.playerId];
   const hasVoted = !!myVote;
 
@@ -26,6 +26,50 @@ export default function VotingScreen({ gameState, vote }: VotingScreenProps) {
       if (navigator.vibrate) navigator.vibrate([50, 30, 50]);
     }
   };
+
+  // Spectators see vote progress without ability to vote
+  if (gameState.isSpectator) {
+    return (
+      <div className="min-h-dvh flex flex-col p-6 pt-12 animate-fade-in">
+        <h2 className="text-2xl font-bold text-white text-center mb-6">
+          {t('voting.title')}
+        </h2>
+
+        <div className="flex-1 grid grid-cols-2 gap-3 content-start mb-4">
+          {activePlayers.map((player) => (
+            <div
+              key={player.id}
+              className="rounded-2xl p-4 border-2 border-slate-700/60 bg-slate-800/60 flex flex-col items-center gap-2 backdrop-blur-sm"
+            >
+              <div
+                className="w-14 h-14 rounded-full flex items-center justify-center text-2xl"
+                style={{ backgroundColor: player.color + '33' }}
+              >
+                {player.avatar}
+              </div>
+              <span className="font-medium text-white text-sm truncate w-full text-center">
+                {player.name}
+              </span>
+              {player.clue && (
+                <span className="text-slate-400 text-xs truncate w-full text-center">
+                  "{player.clue}"
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="pb-safe">
+          <p className="text-center text-slate-500 text-sm mb-2">
+            {t('voting.voted', { count: votedCount, total: totalCount })}
+          </p>
+          <div className="flex justify-center">
+            <WaitingDots />
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (hasVoted) {
     return (

--- a/client/src/translations.ts
+++ b/client/src/translations.ts
@@ -16,9 +16,11 @@ const translations = {
     'join.code': 'Código de sala',
     'join.name': 'Tu nombre',
     'join.button': 'Unirse',
+    'join.watch': 'Observar',
 
     // Lobby
     'lobby.players': 'jugadores',
+    'lobby.spectators': '{count} observando',
     'lobby.start': 'Comenzar',
     'lobby.waiting': 'Esperando a que {host} inicie la partida...',
     'lobby.minPlayers': 'Se necesitan al menos 3 jugadores',
@@ -79,6 +81,11 @@ const translations = {
     'results.pickHostHint': '¿Quién elige la siguiente palabra?',
     'results.confirm': 'Confirmar',
 
+    // Spectator
+    'spectator.banner': 'Estás observando',
+    'spectator.joinAsPlayer': 'Unirse como jugador',
+    'spectator.watching': 'Observando la partida...',
+
     // Connection
     'connection.reconnecting': 'Reconectando...',
 
@@ -120,9 +127,11 @@ const translations = {
     'join.code': 'Room code',
     'join.name': 'Your name',
     'join.button': 'Join',
+    'join.watch': 'Watch',
 
     // Lobby
     'lobby.players': 'players',
+    'lobby.spectators': '{count} watching',
     'lobby.start': 'Start',
     'lobby.waiting': 'Waiting for {host} to start the game...',
     'lobby.minPlayers': 'At least 3 players needed',
@@ -182,6 +191,11 @@ const translations = {
     'results.pickHost': 'Pick next host',
     'results.pickHostHint': 'Who picks the next word?',
     'results.confirm': 'Confirm',
+
+    // Spectator
+    'spectator.banner': 'You are spectating',
+    'spectator.joinAsPlayer': 'Join as player',
+    'spectator.watching': 'Watching the game...',
 
     // Connection
     'connection.reconnecting': 'Reconnecting...',

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -15,6 +15,7 @@ export interface PlayerView {
   avatar: string;
   color: string;
   isHost: boolean;
+  isSpectator: boolean;
   hasSeenRole: boolean;
   clue: string | null;
   isEliminated: boolean;
@@ -26,8 +27,10 @@ export interface GameState {
   phase: GamePhase;
   mode: GameMode;
   players: PlayerView[];
+  spectatorCount: number;
   secretWord: string | null;
   isImpostor: boolean;
+  isSpectator: boolean;
   impostorId: string | null;
   votes: Record<string, string>;
   round: number;

--- a/server/src/gameManager.ts
+++ b/server/src/gameManager.ts
@@ -54,6 +54,7 @@ export class GameManager {
           avatar: AVATARS[0],
           color: COLORS[0],
           isHost: true,
+          isSpectator: false,
           hasSeenRole: false,
           clue: null,
           isEliminated: false,
@@ -106,6 +107,7 @@ export class GameManager {
       avatar: availableAvatar,
       color: COLORS[game.players.length % COLORS.length],
       isHost: false,
+      isSpectator: false,
       hasSeenRole: false,
       clue: null,
       isEliminated: false,
@@ -113,6 +115,51 @@ export class GameManager {
     };
     game.players.push(player);
     this.playerGameMap.set(playerId, code.toUpperCase());
+    return { game };
+  }
+
+  addSpectator(code: string, playerId: string, socketId: string, playerName: string): { game?: Game; error?: string } {
+    const game = this.games.get(code.toUpperCase());
+    if (!game) return { error: 'room_not_found' };
+    if (game.players.some((p) => p.name.toLowerCase() === playerName.toLowerCase())) {
+      return { error: 'name_taken' };
+    }
+    if (game.players.length >= 15) return { error: 'room_full' };
+
+    const usedAvatars = new Set(game.players.map((p) => p.avatar));
+    const availableAvatar = AVATARS.find((a) => !usedAvatars.has(a)) || AVATARS[game.players.length % AVATARS.length];
+
+    const spectator: Player = {
+      id: playerId,
+      socketId,
+      name: playerName,
+      avatar: availableAvatar,
+      color: COLORS[game.players.length % COLORS.length],
+      isHost: false,
+      isSpectator: true,
+      hasSeenRole: false,
+      clue: null,
+      isEliminated: false,
+      disconnectedAt: null,
+    };
+    game.players.push(spectator);
+    this.playerGameMap.set(playerId, code.toUpperCase());
+    return { game };
+  }
+
+  convertToPlayer(playerId: string, code: string): { game?: Game; error?: string } {
+    const game = this.games.get(code);
+    if (!game) return { error: 'room_not_found' };
+    if (game.phase !== 'lobby') return { error: 'wrong_phase' };
+
+    const player = game.players.find((p) => p.id === playerId);
+    if (!player) return { error: 'player_not_found' };
+    if (!player.isSpectator) return { error: 'already_player' };
+
+    const nonSpectatorCount = game.players.filter((p) => !p.isSpectator).length;
+    if (nonSpectatorCount >= 15) return { error: 'room_full' };
+
+    player.isSpectator = false;
     return { game };
   }
 
@@ -196,7 +243,7 @@ export class GameManager {
   skipTurn(code: string): { game?: Game } {
     const game = this.games.get(code);
     if (!game || game.phase !== 'clues') return {};
-    const activePlayers = game.players.filter((p) => !p.isEliminated);
+    const activePlayers = game.players.filter((p) => !p.isEliminated && !p.isSpectator);
     if (game.turnIndex < activePlayers.length) {
       game.turnIndex++;
     }
@@ -235,6 +282,7 @@ export class GameManager {
   private _removePlayerFromGame(code: string, game: Game, playerIndex: number, playerId: string): { game?: Game; hostChanged?: boolean; gameEnded?: boolean; code?: string } {
     const wasHost = game.players[playerIndex].isHost;
     const wasImpostor = game.players[playerIndex].id === game.impostorId;
+    const wasSpectator = game.players[playerIndex].isSpectator;
     game.players.splice(playerIndex, 1);
     this.playerGameMap.delete(playerId);
 
@@ -251,6 +299,11 @@ export class GameManager {
       return { gameEnded: true, code };
     }
 
+    // Spectator leaving doesn't affect game state
+    if (wasSpectator) {
+      return { game, code };
+    }
+
     // If impostor left during active game, end the game
     if (wasImpostor && game.phase !== 'lobby' && game.phase !== 'results') {
       this.clearTurnTimer(code);
@@ -258,8 +311,9 @@ export class GameManager {
       return { game, gameEnded: true, code };
     }
 
-    // Too few players during active game
-    if (game.players.length < 3 && game.phase !== 'lobby' && game.phase !== 'results') {
+    // Too few actual players during active game
+    const actualPlayers = game.players.filter((p) => !p.isSpectator);
+    if (actualPlayers.length < 3 && game.phase !== 'lobby' && game.phase !== 'results') {
       this.clearTurnTimer(code);
       game.phase = 'results';
       return { game, gameEnded: true, code };
@@ -267,14 +321,16 @@ export class GameManager {
 
     let hostChanged = false;
     if (wasHost && game.players.length > 0) {
-      game.players[0].isHost = true;
-      game.hostId = game.players[0].id;
+      // Transfer host to first non-spectator player, or first player if all are spectators
+      const nextHost = game.players.find((p) => !p.isSpectator) || game.players[0];
+      nextHost.isHost = true;
+      game.hostId = nextHost.id;
       hostChanged = true;
     }
 
     // Fix turnIndex if needed during clues
     if (game.phase === 'clues') {
-      const activePlayers = game.players.filter((p) => !p.isEliminated);
+      const activePlayers = game.players.filter((p) => !p.isEliminated && !p.isSpectator);
       if (game.turnIndex >= activePlayers.length) {
         game.turnIndex = 0;
       }
@@ -287,7 +343,8 @@ export class GameManager {
     const game = this.games.get(code);
     if (!game) return { error: 'room_not_found' };
     if (game.hostId !== playerId) return { error: 'not_host' };
-    if (game.players.length < 3) return { error: 'not_enough_players' };
+    const actualPlayers = game.players.filter((p) => !p.isSpectator);
+    if (actualPlayers.length < 3) return { error: 'not_enough_players' };
 
     game.phase = 'setup';
     return { game };
@@ -301,15 +358,17 @@ export class GameManager {
 
     game.secretWord = word.trim();
 
-    // Randomly pick impostor (exclude the host — they chose the word)
-    const nonHostPlayers = game.players.filter((p) => p.id !== playerId);
+    // Randomly pick impostor (exclude the host and spectators — host chose the word)
+    const nonHostPlayers = game.players.filter((p) => p.id !== playerId && !p.isSpectator);
     const randomIndex = Math.floor(Math.random() * nonHostPlayers.length);
     game.impostorId = nonHostPlayers[randomIndex].id;
 
-    // Reset reveal state
+    // Reset reveal state (only for actual players, not spectators)
     game.players.forEach((p) => {
-      p.hasSeenRole = false;
-      p.clue = null;
+      if (!p.isSpectator) {
+        p.hasSeenRole = false;
+        p.clue = null;
+      }
     });
     game.votes = {};
     game.round = 1;
@@ -326,11 +385,13 @@ export class GameManager {
 
     const player = game.players.find((p) => p.id === playerId);
     if (!player) return { error: 'player_not_found' };
+    if (player.isSpectator) return { error: 'spectator_cannot_act' };
 
     player.hasSeenRole = true;
 
-    // Check if all players have seen their role
-    const allReady = game.players.every((p) => p.hasSeenRole);
+    // Check if all actual players have seen their role (spectators excluded)
+    const actualPlayers = game.players.filter((p) => !p.isSpectator);
+    const allReady = actualPlayers.every((p) => p.hasSeenRole);
     if (allReady) {
       // Local mode goes to 'playing' (in-person), online goes to 'clues'
       game.phase = game.mode === 'local' ? 'playing' : 'clues';
@@ -371,9 +432,11 @@ export class GameManager {
     game.round = 1;
     game.turnIndex = 0;
     game.players.forEach((p) => {
-      p.hasSeenRole = false;
-      p.clue = null;
-      p.isEliminated = false;
+      if (!p.isSpectator) {
+        p.hasSeenRole = false;
+        p.clue = null;
+        p.isEliminated = false;
+      }
     });
 
     return { game };
@@ -384,7 +447,7 @@ export class GameManager {
     if (!game) return { error: 'room_not_found' };
     if (game.phase !== 'clues') return { error: 'wrong_phase' };
 
-    const activePlayers = game.players.filter((p) => !p.isEliminated);
+    const activePlayers = game.players.filter((p) => !p.isEliminated && !p.isSpectator);
     const currentPlayer = activePlayers[game.turnIndex];
     if (!currentPlayer || currentPlayer.id !== playerId) return { error: 'not_your_turn' };
     if (!clue.trim()) return { error: 'empty_clue' };
@@ -407,7 +470,7 @@ export class GameManager {
     game.turnIndex = 0;
     game.turnDeadline = null;
     game.players.forEach((p) => {
-      if (!p.isEliminated) p.clue = null;
+      if (!p.isEliminated && !p.isSpectator) p.clue = null;
     });
 
     return { game };
@@ -432,14 +495,15 @@ export class GameManager {
 
     const voter = game.players.find((p) => p.id === playerId);
     if (!voter) return { error: 'player_not_found' };
+    if (voter.isSpectator) return { error: 'spectator_cannot_act' };
 
     const target = game.players.find((p) => p.id === votedForId);
     if (!target) return { error: 'target_not_found' };
 
     game.votes[playerId] = votedForId;
 
-    // Check if all active players have voted
-    const activePlayers = game.players.filter((p) => !p.isEliminated);
+    // Check if all active players have voted (spectators excluded)
+    const activePlayers = game.players.filter((p) => !p.isEliminated && !p.isSpectator);
     const allVoted = activePlayers.every((p) => game.votes[p.id]);
 
     if (allVoted) {
@@ -462,9 +526,11 @@ export class GameManager {
     game.turnIndex = 0;
     game.turnDeadline = null;
     game.players.forEach((p) => {
-      p.hasSeenRole = false;
-      p.clue = null;
-      p.isEliminated = false;
+      if (!p.isSpectator) {
+        p.hasSeenRole = false;
+        p.clue = null;
+        p.isEliminated = false;
+      }
     });
 
     return { game };
@@ -490,8 +556,17 @@ export class GameManager {
   getPersonalizedState(game: Game, playerId: string): PersonalizedGameState {
     const player = game.players.find((p) => p.id === playerId);
     const isHost = player?.isHost ?? false;
-    const isImpostor = game.impostorId === playerId;
+    const isSpectator = player?.isSpectator ?? false;
+    const isImpostor = !isSpectator && game.impostorId === playerId;
     const host = game.players.find((p) => p.isHost);
+    const spectatorCount = game.players.filter((p) => p.isSpectator).length;
+
+    // Spectators: hide secret word and impostor identity until results
+    const showSecretWord = game.phase === 'results'
+      ? game.secretWord
+      : (isSpectator || isImpostor)
+        ? null
+        : game.secretWord;
 
     return {
       code: game.code,
@@ -503,19 +578,16 @@ export class GameManager {
         avatar: p.avatar,
         color: p.color,
         isHost: p.isHost,
+        isSpectator: p.isSpectator,
         hasSeenRole: p.hasSeenRole,
         clue: p.clue,
         isEliminated: p.isEliminated,
         isConnected: p.disconnectedAt === null,
       })),
-      // Only show word to non-impostors during reveal/clues/voting/playing
-      secretWord:
-        game.phase === 'results'
-          ? game.secretWord
-          : isImpostor
-            ? null
-            : game.secretWord,
+      spectatorCount,
+      secretWord: showSecretWord,
       isImpostor,
+      isSpectator,
       // Only reveal impostor during results
       impostorId: game.phase === 'results' ? game.impostorId : null,
       votes: game.phase === 'results' ? game.votes : this.getVoteProgress(game, playerId),

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -16,6 +16,7 @@ export interface Player {
   avatar: string;
   color: string;
   isHost: boolean;
+  isSpectator: boolean;
   hasSeenRole: boolean;
   clue: string | null;
   isEliminated: boolean;
@@ -49,13 +50,16 @@ export interface PersonalizedGameState {
     avatar: string;
     color: string;
     isHost: boolean;
+    isSpectator: boolean;
     hasSeenRole: boolean;
     clue: string | null;
     isEliminated: boolean;
     isConnected: boolean;
   }>;
+  spectatorCount: number;
   secretWord: string | null;
   isImpostor: boolean;
+  isSpectator: boolean;
   impostorId: string | null;
   votes: Record<string, string>;
   round: number;


### PR DESCRIPTION
## Summary
This PR adds a spectator mode that allows players to join games as observers without participating in gameplay. Spectators can watch the game progress in real-time and optionally convert to active players during the lobby phase.

## Key Changes

### Client-side
- **New SpectatorBanner component**: Displays a banner when user is spectating, with an option to join as a player during lobby
- **JoinScreen updates**: Added "Watch" button alongside "Join" to allow users to enter spectator mode
- **Game state tracking**: Added `isSpectator` flag to GameState and PlayerView types, plus `spectatorCount` to track observers
- **Screen-specific spectator views**:
  - RevealScreen: Shows progress bar of players ready instead of role reveal
  - VotingScreen: Displays voting progress without ability to vote
  - CluesScreen: Prevents spectators from taking turns
  - LobbyScreen: Shows spectator count and allows conversion to player
  - PlayingScreen & ResultsScreen: Filters out spectators from player displays
- **UI adjustments**: Added padding to accommodate spectator banner, updated player counts to exclude spectators

### Server-side
- **addSpectator method**: Creates a new spectator player with `isSpectator: true` flag
- **convertToPlayer method**: Allows spectators to become active players during lobby phase only
- **Game logic updates**: Modified all game phase logic to exclude spectators from:
  - Active player counts and turn calculations
  - Role assignments and clue submissions
  - Voting mechanics
  - Host transfer (prioritizes non-spectators)
- **State personalization**: Spectators don't see the secret word until results phase

### Translations
- Added Spanish and English translations for spectator-related UI strings:
  - "You are spectating" / "Estás observando"
  - "Join as player" / "Unirse como jugador"
  - Spectator count display in lobby

## Implementation Details
- Spectators are treated as regular players in the data model but with `isSpectator: true`
- Spectators cannot perform game actions (voting, giving clues, etc.) - these are validated server-side
- Spectators can only convert to players during the lobby phase
- When a host leaves, the system prioritizes transferring host status to a non-spectator player
- Spectators are excluded from all game mechanics calculations (active player counts, turn order, etc.)

https://claude.ai/code/session_014o5hQvNpaDh927qkLZXrZr