### PR TITLE
Add player elimination across rounds (#12)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import CluesScreen from './screens/CluesScreen';
 import VotingScreen from './screens/VotingScreen';
 import PlayingScreen from './screens/PlayingScreen';
 import ImpostorGuessScreen from './screens/ImpostorGuessScreen';
+import EliminationResultsScreen from './screens/EliminationResultsScreen';
 import ResultsScreen from './screens/ResultsScreen';
 import LeaveButton from './components/LeaveButton';
 import SpectatorBanner from './components/SpectatorBanner';
@@ -34,6 +35,7 @@ export default function App() {
   const [joinCode] = useState(initialJoinCode);
 
   const isSpectator = game.gameState?.isSpectator ?? false;
+  const isEliminated = game.gameState?.players.find((p) => p.id === game.gameState?.playerId)?.isEliminated ?? false;
 
   const renderScreen = () => {
     // If in a game, show the phase-appropriate screen
@@ -46,6 +48,7 @@ export default function App() {
               gameState={gs}
               startGame={game.startGame}
               setMode={game.setMode}
+              setElimination={game.setElimination}
               convertToPlayer={game.convertToPlayer}
             />
           );
@@ -76,6 +79,13 @@ export default function App() {
             <ImpostorGuessScreen
               gameState={gs}
               guessWord={game.guessWord}
+            />
+          );
+        case 'elimination-results':
+          return (
+            <EliminationResultsScreen
+              gameState={gs}
+              continueAfterElimination={game.continueAfterElimination}
             />
           );
         case 'results':
@@ -134,11 +144,12 @@ export default function App() {
             {lang.t('connection.reconnecting')}
           </div>
         )}
-        {/* Spectator banner */}
-        {game.screen === 'game' && isSpectator && (
+        {/* Spectator / eliminated banner */}
+        {game.screen === 'game' && (isSpectator || isEliminated) && (
           <SpectatorBanner
             canConvert={game.gameState?.phase === 'lobby'}
             onConvert={game.convertToPlayer}
+            isEliminated={isEliminated}
           />
         )}
         {/* Leave button on all game screens */}

--- a/client/src/components/PlayerCard.tsx
+++ b/client/src/components/PlayerCard.tsx
@@ -27,7 +27,7 @@ export default function PlayerCard({
           : 'border-slate-700/60'
       } ${onClick && !disabled ? 'cursor-pointer active:scale-[0.97]' : ''} ${
         disabled ? 'opacity-50' : ''
-      }`}
+      } ${player.isEliminated ? 'opacity-40 grayscale' : ''}`}
     >
       <div
         className="w-11 h-11 rounded-full flex items-center justify-center text-xl shrink-0"
@@ -36,7 +36,9 @@ export default function PlayerCard({
         {player.avatar}
       </div>
       <div className="flex-1 min-w-0">
-        <div className="font-semibold text-white truncate flex items-center gap-2">
+        <div className={`font-semibold truncate flex items-center gap-2 ${
+          player.isEliminated ? 'text-slate-500 line-through' : 'text-white'
+        }`}>
           {player.name}
           {player.isHost && (
             <span className="text-xs bg-violet-600/30 text-violet-400 px-2 py-0.5 rounded-full">
@@ -46,6 +48,11 @@ export default function PlayerCard({
           {player.isSpectator && (
             <span className="text-xs bg-amber-600/30 text-amber-400 px-2 py-0.5 rounded-full">
               Spectator
+            </span>
+          )}
+          {player.isEliminated && (
+            <span className="text-xs bg-slate-600/30 text-slate-400 px-2 py-0.5 rounded-full">
+              ✗
             </span>
           )}
           {!player.isConnected && (

--- a/client/src/components/SpectatorBanner.tsx
+++ b/client/src/components/SpectatorBanner.tsx
@@ -3,15 +3,18 @@ import { useLanguage } from '../hooks/useLanguage';
 interface SpectatorBannerProps {
   canConvert: boolean;
   onConvert: () => void;
+  isEliminated?: boolean;
 }
 
-export default function SpectatorBanner({ canConvert, onConvert }: SpectatorBannerProps) {
+export default function SpectatorBanner({ canConvert, onConvert, isEliminated = false }: SpectatorBannerProps) {
   const { t } = useLanguage();
 
   return (
-    <div className="fixed top-0 left-0 right-0 z-40 bg-amber-600/90 backdrop-blur-sm text-white text-center text-sm py-2 px-4 flex items-center justify-center gap-3">
-      <span>{t('spectator.banner')}</span>
-      {canConvert && (
+    <div className={`fixed top-0 left-0 right-0 z-40 backdrop-blur-sm text-white text-center text-sm py-2 px-4 flex items-center justify-center gap-3 ${
+      isEliminated ? 'bg-slate-600/90' : 'bg-amber-600/90'
+    }`}>
+      <span>{isEliminated ? t('elimination.banner') : t('spectator.banner')}</span>
+      {canConvert && !isEliminated && (
         <button
           onClick={onConvert}
           className="text-xs bg-white/20 hover:bg-white/30 rounded-full px-3 py-1 transition-colors cursor-pointer"

--- a/client/src/hooks/useGameState.ts
+++ b/client/src/hooks/useGameState.ts
@@ -90,6 +90,14 @@ export function useGameState(initialScreen?: AppScreen) {
     emit('game:setMode', { mode });
   }, [emit]);
 
+  const setElimination = useCallback((enabled: boolean) => {
+    emit('game:setElimination', { enabled });
+  }, [emit]);
+
+  const continueAfterElimination = useCallback(() => {
+    emit('game:continueAfterElimination');
+  }, [emit]);
+
   const startGame = useCallback(() => {
     emit('game:start');
   }, [emit]);
@@ -165,6 +173,8 @@ export function useGameState(initialScreen?: AppScreen) {
     watchGame,
     convertToPlayer,
     setMode,
+    setElimination,
+    continueAfterElimination,
     startGame,
     setWord,
     markRoleReady,

--- a/client/src/screens/CluesScreen.tsx
+++ b/client/src/screens/CluesScreen.tsx
@@ -26,7 +26,8 @@ export default function CluesScreen({
 
   const activePlayers = gameState.players.filter((p) => !p.isEliminated && !p.isSpectator);
   const currentPlayer = activePlayers[gameState.turnIndex];
-  const isMyTurn = !gameState.isSpectator && currentPlayer?.id === gameState.playerId;
+  const meEliminated = gameState.players.find((p) => p.id === gameState.playerId)?.isEliminated;
+  const isMyTurn = !gameState.isSpectator && !meEliminated && currentPlayer?.id === gameState.playerId;
   const allDone = gameState.turnIndex >= activePlayers.length;
 
   // Countdown timer based on server turnDeadline
@@ -63,6 +64,12 @@ export default function CluesScreen({
       <h2 className="text-xl font-bold text-white text-center mb-4">
         {t('clues.round', { n: gameState.round })}
       </h2>
+
+      {meEliminated && (
+        <p className="text-center text-slate-500 text-sm mb-2">
+          {t('elimination.youAreEliminated')}
+        </p>
+      )}
 
       {/* Turn order */}
       <div className="flex gap-2 overflow-x-auto pb-3 mb-4 scrollbar-hide">

--- a/client/src/screens/EliminationResultsScreen.tsx
+++ b/client/src/screens/EliminationResultsScreen.tsx
@@ -1,0 +1,163 @@
+import { useState, useEffect } from 'react';
+import Button from '../components/Button';
+import WaitingDots from '../components/WaitingDots';
+import { useLanguage } from '../hooks/useLanguage';
+import type { GameState } from '../types';
+
+interface EliminationResultsScreenProps {
+  gameState: GameState;
+  continueAfterElimination: () => void;
+}
+
+export default function EliminationResultsScreen({
+  gameState,
+  continueAfterElimination,
+}: EliminationResultsScreenProps) {
+  const { t } = useLanguage();
+  const [phase, setPhase] = useState<'suspense' | 'reveal'>('suspense');
+
+  useEffect(() => {
+    const timer = setTimeout(() => setPhase('reveal'), 1500);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const eliminatedPlayer = gameState.lastEliminatedId
+    ? gameState.players.find((p) => p.id === gameState.lastEliminatedId)
+    : null;
+  const wasTie = !gameState.lastEliminatedId;
+  const activePlayers = gameState.players.filter((p) => !p.isEliminated && !p.isSpectator);
+
+  // Vote breakdown
+  const voteCounts: Record<string, number> = {};
+  for (const votedFor of Object.values(gameState.votes)) {
+    voteCounts[votedFor] = (voteCounts[votedFor] || 0) + 1;
+  }
+
+  if (phase === 'suspense') {
+    return (
+      <div className="min-h-dvh flex flex-col items-center justify-center p-6 animate-fade-in">
+        <h2 className="text-2xl font-bold text-white mb-4">{t('voting.title')}</h2>
+        <div className="flex gap-2">
+          <span className="w-3 h-3 rounded-full bg-violet-400 animate-bounce [animation-delay:0ms]" />
+          <span className="w-3 h-3 rounded-full bg-violet-400 animate-bounce [animation-delay:200ms]" />
+          <span className="w-3 h-3 rounded-full bg-violet-400 animate-bounce [animation-delay:400ms]" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-dvh flex flex-col p-6 animate-fade-in">
+      <div className="flex-1 flex flex-col items-center justify-center">
+        {/* Eliminated player reveal or tie */}
+        {wasTie ? (
+          <div className="animate-scale-in text-center mb-6">
+            <div className="w-24 h-24 rounded-full flex items-center justify-center text-5xl mx-auto mb-4 bg-slate-700/50">
+              🤝
+            </div>
+            <h2 className="text-2xl font-bold text-amber-400 mb-1">
+              {t('elimination.tied')}
+            </h2>
+          </div>
+        ) : eliminatedPlayer ? (
+          <div className="animate-scale-in text-center mb-6">
+            <div
+              className="w-24 h-24 rounded-full flex items-center justify-center text-5xl mx-auto mb-4 opacity-50 grayscale"
+              style={{ backgroundColor: eliminatedPlayer.color + '33' }}
+            >
+              {eliminatedPlayer.avatar}
+            </div>
+            <h2 className="text-2xl font-bold text-rose-400 mb-1">
+              {t('elimination.eliminated', { name: eliminatedPlayer.name })}
+            </h2>
+          </div>
+        ) : null}
+
+        {/* Active player count */}
+        <p className="text-slate-400 text-sm mb-6">
+          {t('elimination.remaining', { count: activePlayers.length })}
+        </p>
+
+        {/* Vote breakdown */}
+        <div className="w-full max-w-sm space-y-2 mb-6">
+          {gameState.players
+            .filter((p) => !p.isSpectator && !p.isEliminated && p.id !== gameState.lastEliminatedId)
+            .concat(eliminatedPlayer ? [eliminatedPlayer] : [])
+            .filter((p) => gameState.votes[p.id])
+            .map((player) => {
+              const votedForId = gameState.votes[player.id];
+              const votedFor = gameState.players.find((p) => p.id === votedForId);
+              return (
+                <div
+                  key={player.id}
+                  className="flex items-center gap-2 text-sm bg-slate-800/50 backdrop-blur-sm rounded-xl px-3 py-2"
+                >
+                  <div
+                    className="w-7 h-7 rounded-full flex items-center justify-center text-xs shrink-0"
+                    style={{ backgroundColor: player.color + '33' }}
+                  >
+                    {player.avatar}
+                  </div>
+                  <span className="text-slate-300">{player.name}</span>
+                  <span className="text-slate-500 mx-1">{t('results.votedFor')}</span>
+                  {votedFor && (
+                    <>
+                      <div
+                        className="w-7 h-7 rounded-full flex items-center justify-center text-xs shrink-0"
+                        style={{ backgroundColor: votedFor.color + '33' }}
+                      >
+                        {votedFor.avatar}
+                      </div>
+                      <span className="text-slate-300">{votedFor.name}</span>
+                    </>
+                  )}
+                </div>
+              );
+            })}
+        </div>
+
+        {/* Elimination history */}
+        {gameState.eliminationHistory.length > 0 && (
+          <div className="w-full max-w-sm mb-6">
+            <p className="text-slate-400 text-xs text-center mb-2 uppercase tracking-wide">
+              {t('elimination.history')}
+            </p>
+            <div className="space-y-1">
+              {gameState.eliminationHistory.map((entry, i) => {
+                const player = gameState.players.find((p) => p.id === entry.playerId);
+                return (
+                  <div key={i} className="flex items-center gap-2 text-sm bg-slate-800/50 rounded-lg px-3 py-1.5">
+                    <span className="text-slate-500">{t('clues.round', { n: entry.round })}</span>
+                    <div
+                      className="w-6 h-6 rounded-full flex items-center justify-center text-xs"
+                      style={{ backgroundColor: player?.color + '33' }}
+                    >
+                      {player?.avatar}
+                    </div>
+                    <span className="text-slate-400 line-through">{entry.playerName}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Host continue button */}
+      <div className="pb-safe">
+        {gameState.isHost ? (
+          <Button onClick={continueAfterElimination}>
+            {t('elimination.continue')}
+          </Button>
+        ) : (
+          <div className="text-center text-slate-400">
+            <p>{t('elimination.waitingContinue', { host: gameState.hostName })}</p>
+            <div className="mt-2">
+              <WaitingDots />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/screens/LobbyScreen.tsx
+++ b/client/src/screens/LobbyScreen.tsx
@@ -9,10 +9,11 @@ interface LobbyScreenProps {
   gameState: GameState;
   startGame: () => void;
   setMode: (mode: GameMode) => void;
+  setElimination: (enabled: boolean) => void;
   convertToPlayer: () => void;
 }
 
-export default function LobbyScreen({ gameState, startGame, setMode, convertToPlayer }: LobbyScreenProps) {
+export default function LobbyScreen({ gameState, startGame, setMode, setElimination, convertToPlayer }: LobbyScreenProps) {
   const { t } = useLanguage();
   const actualPlayers = gameState.players.filter((p) => !p.isSpectator);
   const canStart = actualPlayers.length >= 3;
@@ -74,6 +75,43 @@ export default function LobbyScreen({ gameState, startGame, setMode, convertToPl
             </div>
           )}
         </div>
+
+        {/* Elimination toggle — only in online mode */}
+        {gameState.mode === 'online' && (
+          <div className="mb-4">
+            <p className="text-slate-400 text-xs text-center mb-2 uppercase tracking-wide">
+              {t('lobby.variant')}
+            </p>
+            {gameState.isHost ? (
+              <div className="flex max-w-sm mx-auto bg-slate-800/60 backdrop-blur-sm rounded-xl p-1 gap-1">
+                <button
+                  onClick={() => setElimination(false)}
+                  className={`flex-1 py-2.5 rounded-lg text-sm font-semibold transition-all cursor-pointer ${
+                    !gameState.settings.elimination
+                      ? 'bg-violet-600 text-white'
+                      : 'text-slate-400 hover:text-white'
+                  }`}
+                >
+                  {t('lobby.variantClassic')}
+                </button>
+                <button
+                  onClick={() => setElimination(true)}
+                  className={`flex-1 py-2.5 rounded-lg text-sm font-semibold transition-all cursor-pointer ${
+                    gameState.settings.elimination
+                      ? 'bg-violet-600 text-white'
+                      : 'text-slate-400 hover:text-white'
+                  }`}
+                >
+                  {t('lobby.variantElimination')}
+                </button>
+              </div>
+            ) : (
+              <div className="text-center text-sm text-slate-300">
+                {gameState.settings.elimination ? t('lobby.variantElimination') : t('lobby.variantClassic')}
+              </div>
+            )}
+          </div>
+        )}
 
         {gameState.isSpectator ? (
           <div className="space-y-2">

--- a/client/src/screens/ResultsScreen.tsx
+++ b/client/src/screens/ResultsScreen.tsx
@@ -43,6 +43,9 @@ export default function ResultsScreen({ gameState, playAgain, endGame, transferH
   // If impostor guessed correctly, they win despite being caught
   const impostorWins = !impostorCaught || guessedCorrectly;
 
+  // Elimination mode: impostor survived by attrition (not caught by vote)
+  const eliminationImpostorSurvived = gameState.settings.elimination && !impostorCaught && !hasGuessData;
+
   if (phase === 'suspense') {
     return (
       <div className="min-h-dvh flex flex-col items-center justify-center p-6 animate-fade-in">
@@ -134,7 +137,9 @@ export default function ResultsScreen({ gameState, playAgain, endGame, transferH
                 impostorWins ? 'text-rose-400' : 'text-emerald-400'
               }`}
             >
-              {impostorWins ? t('results.won') : t('results.caught')}
+              {eliminationImpostorSurvived
+                ? t('elimination.impostorSurvived')
+                : impostorWins ? t('results.won') : t('results.caught')}
             </div>
             {/* Show guess info if the impostor had a guess phase */}
             {hasGuessData && (
@@ -186,6 +191,32 @@ export default function ResultsScreen({ gameState, playAgain, endGame, transferH
                 </div>
               );
             })}
+          </div>
+        )}
+
+        {/* Elimination history (elimination mode only) */}
+        {gameState.settings.elimination && gameState.eliminationHistory.length > 0 && (
+          <div className="w-full max-w-sm mb-6">
+            <p className="text-slate-400 text-xs text-center mb-2 uppercase tracking-wide">
+              {t('elimination.history')}
+            </p>
+            <div className="space-y-1">
+              {gameState.eliminationHistory.map((entry, i) => {
+                const player = gameState.players.find((p) => p.id === entry.playerId);
+                return (
+                  <div key={i} className="flex items-center gap-2 text-sm bg-slate-800/50 rounded-lg px-3 py-1.5">
+                    <span className="text-slate-500">{t('clues.round', { n: entry.round })}</span>
+                    <div
+                      className="w-6 h-6 rounded-full flex items-center justify-center text-xs"
+                      style={{ backgroundColor: player?.color + '33' }}
+                    >
+                      {player?.avatar}
+                    </div>
+                    <span className="text-slate-400 line-through">{entry.playerName}</span>
+                  </div>
+                );
+              })}
+            </div>
           </div>
         )}
       </div>

--- a/client/src/screens/VotingScreen.tsx
+++ b/client/src/screens/VotingScreen.tsx
@@ -27,8 +27,10 @@ export default function VotingScreen({ gameState, vote }: VotingScreenProps) {
     }
   };
 
-  // Spectators see vote progress without ability to vote
-  if (gameState.isSpectator) {
+  const meEliminated = gameState.players.find((p) => p.id === gameState.playerId)?.isEliminated;
+
+  // Spectators and eliminated players see vote progress without ability to vote
+  if (gameState.isSpectator || meEliminated) {
     return (
       <div className="min-h-dvh flex flex-col p-6 pt-12 animate-fade-in">
         <h2 className="text-2xl font-bold text-white text-center mb-6">

--- a/client/src/translations.ts
+++ b/client/src/translations.ts
@@ -30,6 +30,9 @@ const translations = {
     'lobby.mode': 'Modo de juego',
     'lobby.modeOnline': 'Online',
     'lobby.modeLocal': 'Presencial',
+    'lobby.variant': 'Variante',
+    'lobby.variantClassic': 'Clásico',
+    'lobby.variantElimination': 'Eliminación',
 
     // Setup
     'setup.title': '¿Cuál es la palabra secreta?',
@@ -92,6 +95,19 @@ const translations = {
     'results.pickHostHint': '¿Quién elige la siguiente palabra?',
     'results.confirm': 'Confirmar',
 
+    // Elimination
+    'elimination.eliminated': '¡{name} ha sido eliminado!',
+    'elimination.tied': 'Empate. Nadie fue eliminado.',
+    'elimination.remaining': '{count} jugadores restantes',
+    'elimination.continue': 'Continuar',
+    'elimination.waitingContinue': 'Esperando a que {host} continúe...',
+    'elimination.history': 'Historial de eliminaciones',
+    'elimination.impostorSurvived': '¡El impostor sobrevivió! Quedan muy pocos jugadores.',
+    'elimination.youAreEliminated': 'Has sido eliminado. Observando...',
+    'elimination.banner': 'Eliminado',
+    'elimination.noElimination': 'Empate',
+    'elimination.votes': '{count} votos',
+
     // Spectator
     'spectator.banner': 'Estás observando',
     'spectator.joinAsPlayer': 'Unirse como jugador',
@@ -152,6 +168,9 @@ const translations = {
     'lobby.mode': 'Game mode',
     'lobby.modeOnline': 'Online',
     'lobby.modeLocal': 'In Person',
+    'lobby.variant': 'Variant',
+    'lobby.variantClassic': 'Classic',
+    'lobby.variantElimination': 'Elimination',
 
     // Setup
     'setup.title': 'What\'s the secret word?',
@@ -213,6 +232,19 @@ const translations = {
     'results.pickHost': 'Pick next host',
     'results.pickHostHint': 'Who picks the next word?',
     'results.confirm': 'Confirm',
+
+    // Elimination
+    'elimination.eliminated': '{name} has been eliminated!',
+    'elimination.tied': 'Tied vote. No one was eliminated.',
+    'elimination.remaining': '{count} players remaining',
+    'elimination.continue': 'Continue',
+    'elimination.waitingContinue': 'Waiting for {host} to continue...',
+    'elimination.history': 'Elimination history',
+    'elimination.impostorSurvived': 'The impostor survived! Too few players remain.',
+    'elimination.youAreEliminated': 'You have been eliminated. Watching...',
+    'elimination.banner': 'Eliminated',
+    'elimination.noElimination': 'Tied',
+    'elimination.votes': '{count} votes',
 
     // Spectator
     'spectator.banner': 'You are spectating',

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -6,6 +6,7 @@ export type GamePhase =
   | 'voting'
   | 'playing'
   | 'impostor-guess'
+  | 'elimination-results'
   | 'results';
 
 export type GameMode = 'online' | 'local';
@@ -45,7 +46,10 @@ export interface GameState {
   hostName: string;
   settings: {
     language: 'es' | 'en';
+    elimination: boolean;
   };
+  eliminationHistory: Array<{ round: number; playerName: string; playerId: string }>;
+  lastEliminatedId: string | null;
 }
 
 export type AppScreen = 'home' | 'create' | 'join' | 'game';

--- a/server/src/handlers.ts
+++ b/server/src/handlers.ts
@@ -142,6 +142,31 @@ export function registerHandlers(io: Server, gm: GameManager) {
       broadcastState(game.code);
     });
 
+    socket.on('game:setElimination', ({ enabled }: { enabled: boolean }) => {
+      if (!playerId) return;
+      const game = gm.findGameByPlayerId(playerId);
+      if (!game) return;
+      const { error } = gm.setElimination(playerId, game.code, enabled);
+      if (error) {
+        socket.emit('game:error', { message: error });
+        return;
+      }
+      broadcastState(game.code);
+    });
+
+    socket.on('game:continueAfterElimination', () => {
+      if (!playerId) return;
+      const game = gm.findGameByPlayerId(playerId);
+      if (!game) return;
+      const { error } = gm.continueAfterElimination(playerId, game.code);
+      if (error) {
+        socket.emit('game:error', { message: error });
+        return;
+      }
+      startTurnTimerIfNeeded(game.code);
+      broadcastState(game.code);
+    });
+
     socket.on('game:start', () => {
       if (!playerId) return;
       const game = gm.findGameByPlayerId(playerId);

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -6,6 +6,7 @@ export type GamePhase =
   | 'voting'
   | 'playing'
   | 'impostor-guess'
+  | 'elimination-results'
   | 'results';
 
 export type GameMode = 'online' | 'local';
@@ -41,7 +42,10 @@ export interface Game {
   guessDeadline: number | null;
   settings: {
     language: 'es' | 'en';
+    elimination: boolean;
   };
+  eliminationHistory: Array<{ round: number; playerId: string }>;
+  lastEliminatedId: string | null;
 }
 
 export interface PersonalizedGameState {
@@ -77,5 +81,8 @@ export interface PersonalizedGameState {
   hostName: string;
   settings: {
     language: 'es' | 'en';
+    elimination: boolean;
   };
+  eliminationHistory: Array<{ round: number; playerName: string; playerId: string }>;
+  lastEliminatedId: string | null;
 }


### PR DESCRIPTION
## Summary
- Adds **Elimination** game variant (toggle in lobby, online mode only) where each voting round eliminates the most-voted player
- Eliminated players become watchers — greyed out with strikethrough, can observe but can't vote or submit clues
- Game loops (clues → voting → elimination → clues...) until the impostor is eliminated (group wins + guess phase) or only 2 players remain (impostor wins by survival)
- Tied votes result in no elimination; game continues to next round
- New between-round **EliminationResultsScreen** with suspense animation, vote breakdown, and elimination history timeline
- Impostor identity and secret word persist across all rounds

## Test plan
- [ ] Toggle elimination mode in lobby (only appears for online mode, host-only control)
- [ ] Play through: clues → voting → non-impostor eliminated → elimination-results → continue → more clues
- [ ] Verify eliminated players see "Eliminated" banner and can watch but not vote/submit clues
- [ ] Verify game ends when impostor is voted out (with guess phase)
- [ ] Verify game ends when only 2 players remain (impostor wins)
- [ ] Verify tie vote → no elimination → game continues
- [ ] Verify Play Again resets all elimination state
- [ ] Verify player disconnection during elimination mode handles correctly

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)