### PR TITLE
Fix host phone sleep kicking everyone from the game

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
 import { LanguageContext, useLanguageProvider } from './hooks/useLanguage';
 import { useGameState } from './hooks/useGameState';
+import { useWakeLock } from './hooks/useWakeLock';
 import { getTheme } from './themes';
 import HomeScreen from './screens/HomeScreen';
 import ProfileScreen from './screens/ProfileScreen';
@@ -40,6 +41,9 @@ export default function App() {
 
   const isSpectator = game.gameState?.isSpectator ?? false;
   const isEliminated = game.gameState?.players.find((p) => p.id === game.gameState?.playerId)?.isEliminated ?? false;
+
+  // Keep screen awake during active game phases so phones don't sleep mid-game
+  useWakeLock(game.gameState?.phase);
 
   const renderScreen = () => {
     // If in a game, show the phase-appropriate screen

--- a/client/src/hooks/useWakeLock.ts
+++ b/client/src/hooks/useWakeLock.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import type { GamePhase } from '../types';
+
+// Keep screen awake during active gameplay so the host's phone doesn't sleep
+const ACTIVE_PHASES: GamePhase[] = [
+  'reveal',
+  'clues',
+  'voting',
+  'playing',
+  'discussion',
+  'impostor-guess',
+  'elimination-results',
+];
+
+export function useWakeLock(phase: GamePhase | undefined) {
+  useEffect(() => {
+    if (!phase || !ACTIVE_PHASES.includes(phase)) return;
+    if (!('wakeLock' in navigator)) return;
+
+    let lock: WakeLockSentinel | null = null;
+
+    const request = async () => {
+      try {
+        lock = await navigator.wakeLock.request('screen');
+      } catch {
+        // Wake lock not granted — not critical, ignore silently
+      }
+    };
+
+    // Re-request after the page becomes visible again (browser releases the
+    // lock automatically when the tab goes into the background)
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') request();
+    };
+
+    request();
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      lock?.release();
+    };
+  }, [phase]);
+}

--- a/server/src/gameManager.ts
+++ b/server/src/gameManager.ts
@@ -15,7 +15,7 @@ const CONSONANTS = 'BCDFGHJKLMNPRSTV';
 const VOWELS = 'AEIOU';
 
 // Grace period before actually removing a disconnected player
-const DISCONNECT_GRACE_MS = 30_000; // 30 seconds
+const DISCONNECT_GRACE_MS = 120_000; // 2 minutes — phones lock in ~30-60s, give ample time to rejoin
 // Time limit for impostor's word guess
 const GUESS_TURN_MS = 15_000; // 15 seconds
 


### PR DESCRIPTION
## Problem

When the host's phone screen locks during an in-person game, the WebSocket connection drops. The server previously had a **30-second grace period** before permanently removing the player — shorter than most phones' default auto-lock timers (30–60s). Once the host was removed, if fewer than 3 players remained, `game:ended` was broadcast to everyone.

## Fixes

**1. Extend disconnect grace period: 30s → 2 minutes** (`server/src/gameManager.ts`)

Gives the host (and any player) enough time to wake their phone and reconnect without the game ending.

**2. Screen Wake Lock API** (`client/src/hooks/useWakeLock.ts`)

During active game phases (reveal, clues, voting, discussion, playing, impostor-guess, elimination-results), the app requests a Screen Wake Lock so the host's phone display stays on while playing — preventing the disconnect in the first place. The lock is automatically re-requested if the user switches apps and returns.

## Verified

Automated socket.io test confirmed: 31 seconds after host socket drops, the player tab still shows an active game (grace period is now 2min, not 30s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)